### PR TITLE
updated sparql query for sponsor_def.json

### DIFF
--- a/uf_examples/sponsors/sponsor_def.json
+++ b/uf_examples/sponsors/sponsor_def.json
@@ -1,7 +1,7 @@
 {
     "entity_def": {
         "order_by": "ccn",
-        "entity_sparql": "?uri a foaf:Organization . ?uri uf:sponsorId ?sponsorid .",
+        "entity_sparql": "?uri a vivo:FundingOrganization . ?uri ufvivo:sponsorID ?sponsorid .",
         "type": "http://xmlns.com/foaf/0.1/Organization"
     },
     "column_defs": {


### PR DESCRIPTION
I updated the sparql query for the sponsor_def.json so it works with the UF vivo ontology.