### PR TITLE
updated query in get_vivo_sponsorid to work with new ontology

### DIFF
--- a/vivopump.py
+++ b/vivopump.py
@@ -10,6 +10,7 @@ __version__ = "0.7.2"
 import csv
 import string
 import random
+import sys
 
 
 class InvalidDefException(Exception):
@@ -302,7 +303,8 @@ def get_vivo_sponsorid(parms):
     :param: parms: vivo_query parms
     :return: dictionary of uri keyed by sponsorid
     """
-    query = "select ?uri ?sponsorid where {?uri uf:sponsorId ?sponsorid .}"
+
+    query = "select ?uri ?sponsorid where {?uri a vivo:FundingOrganization . ?uri ufvivo:sponsorID ?sponsorid .}"
     a = vivo_query(query, parms)
     sponsorid = [x['sponsorid']['value'] for x in a['results']['bindings']]
     uri = [x['uri']['value'] for x in a['results']['bindings']]


### PR DESCRIPTION
Updated the sparql query in get_vivo_sponsorid, query now matches what is found in the sv.cfg in the uf_examples/sponsors dir. Old query was returning no data.