### PR TITLE
Fixed py_module paths in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,6 @@ setup(
     author_email='mconlon@duraspace.org',
     description='Use CSV files to update data in VIVO and get data from VIVO.  All semantics are externalized in'
         'JSON format definition files.',
-    py_modules=['vivopump', 'pump'],
+    py_modules=['pump.vivopump', 'pump.pump'],
     requires=['rdflib(>=4.2.1)', 'SPARQLWrapper(>=1.6.4)', 'bibtexparser(>=0.6.0)'],
 )


### PR DESCRIPTION
`python setup.py build` fails because it can't find pump.py or vivopump.py. They must be prefixed with the package name if they're not stored in the root folder.